### PR TITLE
fix #13: set seq to screen only when STY is set

### DIFF
--- a/main.go
+++ b/main.go
@@ -147,7 +147,11 @@ func main() {
 	// Detect `screen` terminal type
 	if term := os.Getenv("TERM"); term != "" {
 		if strings.HasPrefix(term, "screen") {
-			seq = seq.Screen()
+			if sty := os.Getenv("STY"); sty != "" {
+				// only when `STY` has been set
+				// it's normal to see `TERM` is `screen` in tmux
+				seq = seq.Screen()
+			}
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -55,7 +55,7 @@ func main() {
 	pflag.Lookup("man").Hidden = true
 
 	if *version {
-		fmt.Printf("%s version %s (%s)", ProjectName, Version, CommitSHA)
+		fmt.Printf("%s version %s (%s)\n", ProjectName, Version, CommitSHA)
 		return
 	}
 


### PR DESCRIPTION
```console
$ echo $TERM
screen-256color
$ ./shcopy 'To use shcopy within a tmux session, make sure that the outer terminal supports OSC 52, and use one of the following options'
$ pbpaste | wc -c
124
```